### PR TITLE
Add Note to docs examples

### DIFF
--- a/docs/examples/template_pool.py
+++ b/docs/examples/template_pool.py
@@ -1,3 +1,7 @@
+# %%
+# .. note::
+# 
+#    The generated animation can be found at the bottom of the page.
 import numpy as np
 from matplotlib import pyplot as plt, animation
 from sklearn.datasets import make_blobs

--- a/docs/examples/template_pool_batch.py
+++ b/docs/examples/template_pool_batch.py
@@ -1,3 +1,7 @@
+# %%
+# .. note::
+# 
+#    The generated animation can be found at the bottom of the page.
 import numpy as np
 from matplotlib import pyplot as plt, animation
 from sklearn.datasets import make_blobs

--- a/docs/examples/template_pool_regression.py
+++ b/docs/examples/template_pool_regression.py
@@ -1,3 +1,7 @@
+# %%
+# .. note::
+# 
+#    The generated animation can be found at the bottom of the page.
 import numpy as np
 from matplotlib import pyplot as plt, animation
 from scipy.stats import uniform

--- a/docs/examples/template_stream.py
+++ b/docs/examples/template_stream.py
@@ -1,3 +1,7 @@
+# %%
+# .. note::
+# 
+#    The generated animation can be found at the bottom of the page.
 import numpy as np
 from matplotlib import pyplot as plt, animation
 from sklearn.datasets import make_blobs


### PR DESCRIPTION
Closes #304

**Additional context**
Instead of moving the example animations, a note was added to refer to the animation.