### PR TITLE
Fix Bug in Core Set in initial selection

### DIFF
--- a/skactiveml/pool/_core_set.py
+++ b/skactiveml/pool/_core_set.py
@@ -301,7 +301,7 @@ def _update_distances(X, cluster_centers, mapping, latest_distance=None):
             latest_distance_copy[latest_distance_copy == 0] = np.inf
         l_distance = np.zeros(shape=X.shape[0])
         l_distance[mapping] = latest_distance_copy[mapping]
-        dist = np.minimum(latest_distance_copy, dist)
+        dist = np.minimum(l_distance, dist)
 
     result_dist = np.full(X.shape[0], np.nan)
     result_dist[mapping] = dist[mapping]

--- a/skactiveml/pool/_core_set.py
+++ b/skactiveml/pool/_core_set.py
@@ -218,10 +218,10 @@ def k_greedy_center(
 
     # initialize the utilities matrix with
     if n_new_cand is None:
-        utilities = np.empty(shape=(batch_size, X.shape[0]))
+        utilities = np.zeros(shape=(batch_size, X.shape[0]))
     elif isinstance(n_new_cand, int):
         if n_new_cand == len(mapping):
-            utilities = np.empty(shape=(batch_size, n_new_cand))
+            utilities = np.zeros(shape=(batch_size, n_new_cand))
         else:
             raise ValueError(
                 "n_new_cand must equal to the length of mapping array"
@@ -295,9 +295,13 @@ def _update_distances(X, cluster_centers, mapping, latest_distance=None):
         dist = np.min(dist_matrix, axis=1)
 
     if latest_distance is not None:
+        sum_dist = np.nansum(latest_distance)
+        latest_distance_copy = latest_distance.copy()
+        if sum_dist == 0:
+            latest_distance_copy[latest_distance_copy == 0] = np.inf
         l_distance = np.zeros(shape=X.shape[0])
-        l_distance[mapping] = latest_distance[mapping]
-        dist = np.minimum(l_distance, dist)
+        l_distance[mapping] = latest_distance_copy[mapping]
+        dist = np.minimum(latest_distance_copy, dist)
 
     result_dist = np.full(X.shape[0], np.nan)
     result_dist[mapping] = dist[mapping]

--- a/skactiveml/pool/_core_set.py
+++ b/skactiveml/pool/_core_set.py
@@ -21,7 +21,7 @@ from sklearn.utils.validation import (
     check_random_state,
     column_or_1d,
 )
-from sklearn.metrics import pairwise_distances
+from sklearn.metrics import pairwise_distances_argmin_min
 
 
 class CoreSet(SingleAnnotatorPoolQueryStrategy):
@@ -291,16 +291,16 @@ def _update_distances(X, cluster_centers, mapping, latest_distance=None):
 
     if len(cluster_centers) > 0:
         cluster_center_feature = X[cluster_centers]
-        dist_matrix = pairwise_distances(X, cluster_center_feature)
-        dist = np.min(dist_matrix, axis=1)
+        _, dist = pairwise_distances_argmin_min(X, cluster_center_feature)
 
     if latest_distance is not None:
         sum_dist = np.nansum(latest_distance)
-        latest_distance_copy = latest_distance.copy()
+        latest_distance_tmp = latest_distance
         if sum_dist == 0:
-            latest_distance_copy[latest_distance_copy == 0] = np.inf
+            latest_distance_tmp = latest_distance.copy()
+            latest_distance_tmp[latest_distance_tmp == 0] = np.inf
         l_distance = np.zeros(shape=X.shape[0])
-        l_distance[mapping] = latest_distance_copy[mapping]
+        l_distance[mapping] = latest_distance_tmp[mapping]
         dist = np.minimum(l_distance, dist)
 
     result_dist = np.full(X.shape[0], np.nan)

--- a/skactiveml/pool/tests/test_core_set.py
+++ b/skactiveml/pool/tests/test_core_set.py
@@ -101,6 +101,11 @@ class TestCoreSet(TemplateSingleAnnotatorPoolQueryStrategy, unittest.TestCase):
         np.testing.assert_array_equal(utilities_6_1, utilities_6_2)
         np.testing.assert_array_equal(utilities_6_1[:, 5:], utilities_6_3)
 
+        # test case 7: initial selection
+        y_7 = np.full(10, MISSING_LABEL)
+        _, utilities = core_set_1.query(
+            X, y_7, batch_size=2, return_utilities=True
+        )
 
 class TestKGreedyCenter(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fix the bug, description in below

### Describe the bug

For Core-Set Algorithm, the initial selection (for the first query cycle with batch size larger than one) doesn't work follow the k-center principle.

### Step to Reproduce

**Code example:**

```
X, y_true = make_blobs(n_samples=200, n_features=2,
                       centers=[[0, 1], [-3, .5], [-1, -1], [2, 1], [1, -.5]],
                       cluster_std=.7, random_state=random_state)
y = np.full(shape=y_true.shape, fill_value=MISSING_LABEL)
qs = CoreSet()
query_idx, utilities = qs.query(X=X, y=y, batch_size=4, return_utilities=True)
```

**‍Actual Behavior‍**
All the query_samples are randomly selected from the dataset.
‍
‍**Expected Behavior**
Only the first one is selected from the entire dataset. The rest of them need to be selected according the k-center principle.

### Error message:

### Context for the issue:

### No response