### PR TITLE
481 match signature type hinting

### DIFF
--- a/skactiveml/utils/_functions.py
+++ b/skactiveml/utils/_functions.py
@@ -112,11 +112,25 @@ def match_signature(wrapped_obj_name, func_name):
                         f" no method {self.func_name}."
                     )
                 reference_function = getattr(reference_object, self.func_name)
-                reference_signature = inspect.signature(
-                    reference_function.__func__
-                )
+                if hasattr(reference_function, "__func__"):
+                    new_sig = inspect.signature(reference_function.__func__)
+                else:
+                    reference_sig = inspect.signature(reference_function)
+                    reference_sig.return_annotation
+                    new_parameters = list(reference_sig.parameters.values())
+                    new_parameters.insert(
+                        0,
+                        inspect.Parameter(
+                            "self",
+                            kind=inspect._ParameterKind.POSITIONAL_OR_KEYWORD,
+                        ),
+                    )
+                    new_sig = inspect.Signature(
+                        new_parameters,
+                        return_annotation=reference_sig.return_annotation,
+                    )
                 function_decorator = with_signature(
-                    func_signature=reference_signature,
+                    func_signature=new_sig,
                     func_name=self.fn.__name__,
                 )
                 fn = function_decorator(self.fn)

--- a/skactiveml/utils/_functions.py
+++ b/skactiveml/utils/_functions.py
@@ -112,11 +112,17 @@ def match_signature(wrapped_obj_name, func_name):
                         f" no method {self.func_name}."
                     )
                 reference_function = getattr(reference_object, self.func_name)
+
+                # check if refrenced function is a method of that object
+                # if it is, use `__func__` to copy the name of the `self``
+                # parameter
+                # if it is not, because it might have been added outside of the
+                # class definition, add a provisory self argument in the first
+                # position
                 if hasattr(reference_function, "__func__"):
                     new_sig = inspect.signature(reference_function.__func__)
                 else:
                     reference_sig = inspect.signature(reference_function)
-                    reference_sig.return_annotation
                     new_parameters = list(reference_sig.parameters.values())
                     new_parameters.insert(
                         0,
@@ -129,6 +135,9 @@ def match_signature(wrapped_obj_name, func_name):
                         new_parameters,
                         return_annotation=reference_sig.return_annotation,
                     )
+
+                # create a wrapper with the new signature and the correct
+                # function name
                 function_decorator = with_signature(
                     func_signature=new_sig,
                     func_name=self.fn.__name__,

--- a/skactiveml/utils/_functions.py
+++ b/skactiveml/utils/_functions.py
@@ -115,9 +115,7 @@ def match_signature(wrapped_obj_name, func_name):
                 reference_function = getattr(reference_object, self.func_name)
                 reference_signature = inspect.signature(reference_function)
                 new_fn_name = self.fn.__name__
-                sig_str = (
-                    f"{new_fn_name}(self, {str(reference_signature)[1:-1]})"
-                )
+                sig_str = f"{new_fn_name}(self, {str(reference_signature)[1:]}"
                 fn = with_signature(sig_str)(self.fn)
                 out = MethodType(fn, obj)
             else:

--- a/skactiveml/utils/_functions.py
+++ b/skactiveml/utils/_functions.py
@@ -113,12 +113,11 @@ def match_signature(wrapped_obj_name, func_name):
                     )
                 reference_function = getattr(reference_object, self.func_name)
 
-                # check if refrenced function is a method of that object
-                # if it is, use `__func__` to copy the name of the `self``
+                # Check if the refrenced function is a method of that object.
+                # If it is, use `__func__` to copy the name of the `self`
                 # parameter
-                # if it is not, because it might have been added outside of the
-                # class definition, add a provisory self argument in the first
-                # position
+                # If it is not, (i.e. it has been added as a lambda function),
+                # add a provisory self argument in the first position
                 if hasattr(reference_function, "__func__"):
                     new_sig = inspect.signature(reference_function.__func__)
                 else:

--- a/skactiveml/utils/_functions.py
+++ b/skactiveml/utils/_functions.py
@@ -111,12 +111,15 @@ def match_signature(wrapped_obj_name, func_name):
                         f"This {reference_object} has"
                         f" no method {self.func_name}."
                     )
-
                 reference_function = getattr(reference_object, self.func_name)
-                reference_signature = inspect.signature(reference_function)
-                new_fn_name = self.fn.__name__
-                sig_str = f"{new_fn_name}(self, {str(reference_signature)[1:]}"
-                fn = with_signature(sig_str)(self.fn)
+                reference_signature = inspect.signature(
+                    reference_function.__func__
+                )
+                function_decorator = with_signature(
+                    func_signature=reference_signature,
+                    func_name=self.fn.__name__,
+                )
+                fn = function_decorator(self.fn)
                 out = MethodType(fn, obj)
             else:
                 out = self.fn


### PR DESCRIPTION
Closes #481

**Additional context**
Fixes the match_signature decorator to work correctly with functions, that have a type hint for their return value.