### PR TITLE
520 adjust docstring for emc

### DIFF
--- a/skactiveml/pool/_expected_model_change_maximization.py
+++ b/skactiveml/pool/_expected_model_change_maximization.py
@@ -25,7 +25,7 @@ class ExpectedModelChangeMaximization(SingleAnnotatorPoolQueryStrategy):
     This class implements "Expected Model Change" (EMC) [1]_, an active
     learning query strategy designed for linear regression. It chooses those
     samples that have a maximal expected gradient length with respect to the
-    model parameters. While designed for a linear regressor the formulas 
+    model parameters. While designed for a linear regressor the formulas
     obtained from the linear case can be applied to arbitrary regressors.
 
     Parameters


### PR DESCRIPTION
Closes 520
Highlighted EMC is designed for linear regression, but can be used for arbitrary regressors.