### PR TITLE
525 sklearn pipeline bug

### DIFF
--- a/skactiveml/regressor/tests/test_wrapper.py
+++ b/skactiveml/regressor/tests/test_wrapper.py
@@ -83,7 +83,9 @@ class TestWrapper(TemplateSkactivemlRegressor, unittest.TestCase):
 
     def test_pipeline(self):
         base_estimator = SklearnRegressor(GaussianProcessRegressor())
-        estimator = Pipeline([('scaler', StandardScaler()), ('reg', base_estimator)])
+        estimator = Pipeline(
+            [("scaler", StandardScaler()), ("reg", base_estimator)]
+        )
         reg = SklearnRegressor(estimator=estimator)
         y = np.full(3, MISSING_LABEL)
         reg.fit(self.X, y)


### PR DESCRIPTION
Closes 525

Pipelines can be used for the base regressor and classifier wrappers.
Pipelines could not be used for the SklearnNormalRegressor.
The bug was that the SklearnNormalRegressor required the predict method to have return_std.
As the Pipelines accepts the arguments to be passed to the final regressor of the pipeline in an args form the SklearnNormalRegressor throws an error.
A test has been added.