### PR TITLE
529 Fix pytest failing when using workers and add pytest arguments to pyproject.toml

### DIFF
--- a/.github/workflows/external-pull-request.yml
+++ b/.github/workflows/external-pull-request.yml
@@ -29,7 +29,7 @@ jobs:
         pip install -r requirements_extra.txt
     - name: Test with pytest and oldest dependencies
       run: |
-        pytest -n auto --cov=./skactiveml --cov-report=xml --cov-fail-under=100
+        pytest
 
   test_newest_dependencies:
     if: ${{ github.event.pull_request.head.repo.full_name != github.repository }}
@@ -54,7 +54,7 @@ jobs:
         pip install -r requirements_extra.txt
     - name: Test with pytest and newest dependencies
       run: |
-        pytest -n auto --cov=./skactiveml --cov-report=xml --cov-fail-under=100
+        pytest
     - name: 'Upload Coverage Artifact'
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         pip install -r requirements_extra.txt
     - name: Test with pytest and oldest dependencies
       run: |
-        pytest -n auto --cov=./skactiveml --cov-report=xml --cov-fail-under=100
+        pytest
 
   test_newest_dependencies:
     runs-on: ubuntu-latest
@@ -51,7 +51,8 @@ jobs:
         pip install -r requirements_extra.txt
     - name: Test with pytest and newest dependencies
       run: |
-        pytest -n auto --cov=./skactiveml --cov-report=xml
+        # Do not fail to upload the coverage afterwards
+        pytest --cov-fail-under=0
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,14 @@ exclude = [
 Homepage       = "https://scikit-activeml.github.io"
 Source         = "https://github.com/scikit-activeml/scikit-activeml"
 
+[tool.pytest]
+addopts = [
+  "--cov=./skactiveml",
+  "--cov-report=xml",
+  "--cov-fail-under=100"
+]
+testpaths = ["./skactiveml"]
+
 [tool.black]
 line-length = 79
 target-version = ['py311']


### PR DESCRIPTION
Closes #529 

**Additional context**
The pytest arguments are now included in the project.toml, such that when test workers are compatible again, the number only needs to be adjusted in pyproject.toml