### PR TITLE
Fix k-means++ sampling of Badge and factorize its gradient embeddings

### DIFF
--- a/skactiveml/pool/_badge.py
+++ b/skactiveml/pool/_badge.py
@@ -3,9 +3,10 @@ Module implementing the pool-based query strategy Batch Active Learning by
 Diverse Gradient Embedding (BADGE).
 """
 
+import warnings
+
 import numpy as np
 from sklearn import clone
-from sklearn.metrics import pairwise_distances_argmin_min
 
 from ..base import SingleAnnotatorPoolQueryStrategy, SkactivemlClassifier
 from ..utils import (
@@ -26,6 +27,16 @@ class Badge(SingleAnnotatorPoolQueryStrategy):
     of the cross-entropy loss with respect to the last linear layer using the
     model’s pseudo-label. Large gradient norms indicate uncertainty, while
     k-means++ spreads selections to avoid redundancy.
+
+    The gradient embedding of a sample is the Kronecker product
+    `g = kron(q, v)` of its probability residual `q` and its (learned) sample
+    representation `v`. Since inner products factorize as
+    `<g_i, g_j> = <q_i, q_j> * <v_i, v_j>` [2]_, the
+    `(n_samples, n_classes * n_features)` embedding matrix is never
+    materialized. Each k-means++ round only requires two matrix-vector
+    products, which reduces the space complexity from
+    `O(n_samples * n_classes * n_features)` to
+    `O(n_samples * (n_classes + n_features))`.
 
     Parameters
     ----------
@@ -57,6 +68,10 @@ class Badge(SingleAnnotatorPoolQueryStrategy):
     .. [1] J. T. Ash, C. Zhang, A. Krishnamurthy, J. Langford, and A. Agarwal.
        Deep Batch Active Learning by Diverse, Uncertain Gradient Lower Bounds.
        In Int. Conf. Learn. Represent., 2020.
+    .. [2] J. Zhang, Y. Chen, G. Canal, S. Mussmann, A. M. Das, G. Bhatt,
+       Y. Zhu, J. Bilmes, S. S. Du, K. Jamieson, and R. D. Nowak. LabelBench:
+       A Comprehensive Framework for Benchmarking Adaptive Label-Efficient
+       Learning. J. Data-centric Mach. Learn. Res., 2024.
     """
 
     def __init__(
@@ -109,7 +124,9 @@ class Badge(SingleAnnotatorPoolQueryStrategy):
               candidate samples are directly given in `candidates` (not
               necessarily contained in `X`).
         batch_size : int, default=1
-            The number of samples to be selected in one AL cycle.
+            The number of samples to be selected in one AL cycle. If it
+            exceeds the number of unlabeled candidates, it is reduced to that
+            number and a warning is raised.
         return_utilities : bool, default=False
             If `True`, also return the utilities based on the query strategy.
 
@@ -118,7 +135,7 @@ class Badge(SingleAnnotatorPoolQueryStrategy):
         query_indices : numpy.ndarray of shape (batch_size,)
             The query indices indicate for which candidate sample a label is
             to be queried, e.g., `query_indices[0]` indicates the first
-            selected sample.
+            selected sample. A sample is selected at most once per batch.
 
             - If `candidates` is `None` or of shape
               `(n_candidates,)`, the indexing refers to the samples in
@@ -130,7 +147,10 @@ class Badge(SingleAnnotatorPoolQueryStrategy):
             The utilities of samples after each selected sample of the batch,
             e.g., `utilities[0]` indicates the utilities used for selecting
             the first sample (with index `query_indices[0]`) of the batch.
-            Utilities for labeled samples will be set to np.nan.
+            Each row is the k-means++ sampling distribution of the respective
+            round, i.e., its `nansum` is one. Utilities for labeled samples
+            and for samples that have already been selected in an earlier
+            round will be set to np.nan.
 
             - If `candidates` is `None` or of shape
               `(n_candidates,)`, the indexing refers to the samples in
@@ -183,15 +203,35 @@ class Badge(SingleAnnotatorPoolQueryStrategy):
             X_unlbld = X_cand
             unlbld_mapping = np.arange(len(X_cand))
 
+        # If `candidates` is an index array containing labeled samples, the
+        # number of unlabeled candidates may fall below `batch_size`, which
+        # `_validate_data` cannot detect since it only counts candidates.
+        n_unlbld = len(X_unlbld)
+        if n_unlbld == 0:
+            raise ValueError("'candidates' contains no unlabeled samples.")
+        if batch_size > n_unlbld:
+            warnings.warn(
+                f"'batch_size={batch_size}' is larger than number of "
+                f"unlabeled candidates. Instead, "
+                f"'batch_size={n_unlbld}' was set."
+            )
+            batch_size = n_unlbld
+
         # gradient embedding, aka predict class membership probabilities
         probas = clf.predict_proba(X_unlbld, **predict_proba_kwargs)
         if isinstance(probas, tuple):
             probas, X_unlbld = probas
 
+        # Factorized gradient embedding `g_i = kron(q_i, v_i)`, where
+        # `q_i = probas_i - e_{y_pred_i}` is the probability residual and
+        # `v_i` the sample representation. `float64` is required because the
+        # accumulation error of `float32` changes the sampling.
+        probas = np.asarray(probas, dtype=np.float64)
+        V = np.asarray(X_unlbld, dtype=np.float64)
         y_pred = probas.argmax(axis=-1)
-        proba_factor = probas - np.eye(probas.shape[1])[y_pred]
-        g_x = proba_factor[:, :, None] * X_unlbld[:, None, :]
-        g_x = g_x.reshape(*g_x.shape[:-2], -1)
+        Q = probas.copy()
+        Q[np.arange(n_unlbld), y_pred] -= 1
+        g_norm_2 = np.einsum("ij,ij->i", Q, Q) * np.einsum("ij,ij->i", V, V)
 
         # init the utilities
         if mapping is not None:
@@ -204,71 +244,57 @@ class Badge(SingleAnnotatorPoolQueryStrategy):
             )
 
         # sampling with kmeans++
-        query_indicies = []
-        query_indicies_in_unlbld = []
-        idx_in_unlbld = []
-        d_2_s = []
+        query_indices = []
+        query_indices_in_unlbld = []
+        # In the first round, `d_2` holds the squared gradient norms, which
+        # only serve to determine the first center. Afterwards, it is replaced
+        # by the squared distances to that center, such that the origin does
+        # not act as a permanent ghost center in the running minimum.
+        d_2 = g_norm_2.copy()
         for i in range(batch_size):
-            if i == 0:
-                d_2 = _d_2(g_x, idx_in_unlbld)
+            # Zeroing the distances of the already selected centers gives them
+            # zero probability, so that they cannot be drawn a second time.
+            d_2[query_indices_in_unlbld] = 0
+            d_2_sum = d_2.sum()
+            if d_2_sum > 0:
+                d_probas = d_2 / d_2_sum
             else:
-                d_2 = _d_2(g_x, [idx_in_unlbld], d_2_s[i - 1])
-            d_2_s.append(d_2)
-
-            d_2_sum = np.sum(d_2)
-            if d_2_sum == 0:
-                d_2_s[-1] = np.full(shape=len(g_x), fill_value=np.inf)
-                d_2 = np.ones(shape=len(g_x))
-                d_2[query_indicies_in_unlbld] = 0
-                d_2_sum = np.sum(d_2)
-
-            d_probas = d_2 / d_2_sum
+                # Degenerate case of exclusively zero gradient embeddings,
+                # e.g., for the one-hot probabilities of a single-class cold
+                # start. Then, sample uniformly among the remaining samples.
+                d_probas = np.full(n_unlbld, 1 / (n_unlbld - i))
+                d_probas[query_indices_in_unlbld] = 0
 
             utilities[i, unlbld_mapping] = d_probas
-            utilities[i, query_indicies] = np.nan
+            utilities[i, query_indices] = np.nan
 
-            if i == 0 and d_2_sum != 0:
-                idx_in_unlbld = np.argmax(d_2, axis=-1)
+            if i == 0 and d_2_sum > 0:
+                idx_in_unlbld = int(np.argmax(d_2))
             else:
-                idx_in_unlbld_array = self.random_state_.choice(
-                    len(d_probas), 1, replace=False, p=d_probas
+                idx_in_unlbld = int(
+                    self.random_state_.choice(
+                        n_unlbld, 1, replace=False, p=d_probas
+                    )[0]
                 )
-                idx_in_unlbld = idx_in_unlbld_array[0]
-            query_indicies_in_unlbld.append(idx_in_unlbld)
+            query_indices_in_unlbld.append(idx_in_unlbld)
+            query_indices.append(unlbld_mapping[idx_in_unlbld])
 
-            idx = unlbld_mapping[idx_in_unlbld]
-            query_indicies.append(idx)
+            # Squared distance to the newest center via the factorization:
+            # `||g_i - g_c||^2 = ||g_i||^2 + ||g_c||^2
+            #  - 2 * <q_i, q_c> * <v_i, v_c>`. Rounding may produce tiny
+            # negative values, which are rejected by `choice(p=...)`, such
+            # that they are clipped.
+            if i + 1 < batch_size:
+                cross = (Q @ Q[idx_in_unlbld]) * (V @ V[idx_in_unlbld])
+                d_2_new = g_norm_2 + g_norm_2[idx_in_unlbld] - 2 * cross
+                np.maximum(d_2_new, 0, out=d_2_new)
+                if i == 0:
+                    d_2 = d_2_new
+                else:
+                    np.minimum(d_2, d_2_new, out=d_2)
 
+        query_indices = np.array(query_indices)
         if return_utilities:
-            return query_indicies, utilities
+            return query_indices, utilities
         else:
-            return query_indicies
-
-
-def _d_2(g_x, query_indices, d_latest=None):
-    """
-    Calculates the D^2 value of the embedding features of unlabeled data.
-
-    Parameters
-    ----------
-    g_x : np.ndarray of shape (n_unlabeled_samples, n_features)
-        The results after gradient embedding
-    query_indices : numpy.ndarray of shape (n_query_indices,)
-        the query indications that correspond to the unlabeled samples.
-    d_latest : np.ndarray of shape (n_unlabeled_samples,) default=None
-        The distance between each data point and its nearest centre.
-        This is used to simplify the calculation of the later distances for the
-        next selected sample.
-
-    Returns
-    -------
-    D2 : numpy.ndarray of shape (n_unlabeled_samples,)
-        The D^2 value, for the first sample, is the value inf.
-    """
-    if len(query_indices) == 0:
-        return np.sum(g_x**2, axis=-1)
-    query_indices = g_x[query_indices]
-    _, D = pairwise_distances_argmin_min(X=g_x, Y=query_indices)
-    if d_latest is not None:
-        D2 = np.minimum(d_latest, np.square(D))
-    return D2
+            return query_indices

--- a/skactiveml/pool/tests/test_badge.py
+++ b/skactiveml/pool/tests/test_badge.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy as np
+from sklearn.datasets import make_blobs
 from sklearn.linear_model import LogisticRegression
 from sklearn.svm import SVC
 
@@ -15,6 +16,18 @@ from skactiveml.tests.utils import (
     ParzenWindowClassifierEmbedding,
     ParzenWindowClassifierTuple,
 )
+
+
+class SklearnClassifierCosineEmbedding(SklearnClassifier):
+    """`SklearnClassifier` whose `predict_proba` optionally returns a
+    `(proba, embeddings)` tuple, where the embeddings are a nonlinear
+    transformation of `X` and therefore differ from `X` itself."""
+
+    def predict_proba(self, X, return_embeddings=False):
+        probas = super().predict_proba(X)
+        if not return_embeddings:
+            return probas
+        return probas, np.cos(3 * np.asarray(X))
 
 
 class TestBadge(TemplateSingleAnnotatorPoolQueryStrategy, unittest.TestCase):
@@ -44,6 +57,18 @@ class TestBadge(TemplateSingleAnnotatorPoolQueryStrategy, unittest.TestCase):
             init_default_params={"random_state": 42},
             query_default_params_clf=self.query_default_params_clf,
         )
+
+    def _duplicated_pool(self):
+        """Builds a degenerate pool whose unlabeled candidates take only two
+        distinct feature values."""
+        X = np.vstack(
+            [
+                np.array([[0.0, 0.0], [1.0, 1.0]]),
+                np.tile(np.array([[3.0, 3.0], [7.0, 7.0]]), (5, 1)),
+            ]
+        )
+        y = np.hstack([[0, 1], np.full(10, MISSING_LABEL)])
+        return X, y
 
     def test_query_param_clf(self):
         add_test_cases = [
@@ -82,7 +107,7 @@ class TestBadge(TemplateSingleAnnotatorPoolQueryStrategy, unittest.TestCase):
         y_1 = np.hstack([[0, 1], np.full(8, MISSING_LABEL)])
         clf_1 = SklearnClassifier(LogisticRegression(), classes=self.classes)
 
-        self.assertEqual(
+        np.testing.assert_array_equal(
             badge_1.query(X_1, y_1, clf_1), badge_1.query(X_1, y_1, clf_1)
         )
 
@@ -172,4 +197,232 @@ class TestBadge(TemplateSingleAnnotatorPoolQueryStrategy, unittest.TestCase):
         np.testing.assert_array_equal(
             badge_1.query(X_1, y_1, clf_8),
             badge_1.query(X_1, y_1, clf_8),
+        )
+
+    def test_query_distinct_indices_per_batch(self):
+        # A pool whose candidates take only two distinct feature values must
+        # not lead to a sample being selected twice within one batch.
+        X, y = self._duplicated_pool()
+        clf = SklearnClassifier(LogisticRegression(), classes=self.classes)
+        for random_state in range(30):
+            query_indices = Badge(random_state=random_state).query(
+                X, y, clf, batch_size=6
+            )
+            self.assertEqual(len(np.unique(query_indices)), 6)
+
+    def test_query_utilities_are_sampling_distributions(self):
+        # Each row of `utilities` is the sampling distribution of the
+        # respective round, i.e., its `nansum` is one.
+        X, y = self._duplicated_pool()
+        clf = SklearnClassifier(LogisticRegression(), classes=self.classes)
+        _, utilities = Badge(random_state=0).query(
+            X, y, clf, batch_size=6, return_utilities=True
+        )
+        np.testing.assert_allclose(np.nansum(utilities, axis=1), 1)
+
+        X_2, y_2 = make_blobs(
+            n_samples=100, centers=2, n_features=4, random_state=1
+        )
+        y_2 = np.where(np.arange(100) < 6, y_2, MISSING_LABEL).astype(float)
+        _, utilities_2 = Badge(random_state=1).query(
+            X_2, y_2, clf, batch_size=10, return_utilities=True
+        )
+        np.testing.assert_allclose(np.nansum(utilities_2, axis=1), 1)
+
+    def test_query_origin_is_no_permanent_center(self):
+        # Candidates near the origin of the feature space must not be
+        # suppressed once the remaining clusters have been covered.
+        cluster_a = np.array(
+            [[10.0, 10.0], [10.5, 9.5], [9.5, 10.5], [10.2, 10.2]]
+        )
+        cluster_b = np.array(
+            [[-10.0, -10.0], [-10.5, -9.5], [-9.5, -10.5], [-10.2, -10.2]]
+        )
+        cluster_c = np.array(
+            [[0.2, -0.2], [-0.2, 0.2], [0.1, 0.1], [-0.1, -0.1]]
+        )
+        X = np.vstack(
+            [
+                np.array([[3.0, -3.0], [-3.0, 3.0]]),
+                cluster_a,
+                cluster_b,
+                cluster_c,
+            ]
+        )
+        y = np.hstack([[0, 1], np.full(12, MISSING_LABEL)])
+        clf = SklearnClassifier(LogisticRegression(), classes=self.classes)
+        query_indices, utilities = Badge(random_state=1).query(
+            X, y, clf, batch_size=4, return_utilities=True
+        )
+
+        # Once the two outer clusters have been sampled from, the uncovered
+        # cluster near the origin carries the largest utilities.
+        cluster_c_indices = np.arange(10, 14)
+        self.assertGreater(
+            np.nanmin(utilities[2, cluster_c_indices]),
+            np.nanmax(np.delete(utilities[2], cluster_c_indices)),
+        )
+        self.assertTrue(np.isin(query_indices, cluster_c_indices).any())
+
+    def test_query_matches_reference_kmeanspp(self):
+        # The factorized computation agrees per round with the reference
+        # semantics evaluated on explicitly materialized gradient embeddings.
+        X, y_true = make_blobs(
+            n_samples=300, centers=5, n_features=8, random_state=0
+        )
+        y = np.full(300, MISSING_LABEL)
+        lbld_mapping = np.arange(10)
+        y[lbld_mapping] = y_true[lbld_mapping] % 2
+        batch_size = 8
+        clf = SklearnClassifier(
+            LogisticRegression(), classes=self.classes, random_state=0
+        )
+        query_indices, utilities = Badge(random_state=0).query(
+            X, y, clf, batch_size=batch_size, return_utilities=True
+        )
+
+        # Materialize the `(n_unlabeled, n_classes * n_features)` embeddings.
+        unlbld_mapping = np.setdiff1d(np.arange(300), lbld_mapping)
+        probas = clf.fit(X, y).predict_proba(X[unlbld_mapping])
+        proba_factor = probas - np.eye(probas.shape[1])[probas.argmax(-1)]
+        g_x = proba_factor[:, :, None] * X[unlbld_mapping][:, None, :]
+        g_x = g_x.reshape(len(unlbld_mapping), -1)
+        norms_2 = np.sum(g_x**2, axis=-1)
+
+        # The first center is the argmax of the gradient norms.
+        self.assertEqual(query_indices[0], unlbld_mapping[np.argmax(norms_2)])
+
+        query_indices_in_unlbld = [
+            int(np.flatnonzero(unlbld_mapping == idx)[0])
+            for idx in query_indices
+        ]
+        d_2 = None
+        for i in range(batch_size):
+            if i == 0:
+                expected = norms_2 / norms_2.sum()
+            else:
+                idx_in_unlbld = query_indices_in_unlbld[i - 1]
+                d_2_new = np.sum((g_x - g_x[idx_in_unlbld]) ** 2, axis=-1)
+                d_2 = d_2_new if i == 1 else np.minimum(d_2, d_2_new)
+                d_2[query_indices_in_unlbld[:i]] = 0
+                expected = d_2 / d_2.sum()
+
+            # Samples selected in an earlier round are `np.nan`, whereas their
+            # reference probability is zero.
+            row = utilities[i, unlbld_mapping]
+            is_selected = np.isnan(row)
+            np.testing.assert_array_equal(
+                np.flatnonzero(is_selected),
+                np.sort(query_indices_in_unlbld[:i]),
+            )
+            np.testing.assert_allclose(
+                row[~is_selected], expected[~is_selected], rtol=1e-9
+            )
+
+    def test_query_zero_gradient_embeddings(self):
+        # If all gradient embeddings are zero, e.g., for the one-hot
+        # probabilities of a single-class cold start, all remaining samples
+        # are equally likely and the first one is drawn at random.
+        X = np.random.RandomState(42).choice(5, size=(10, 2)).astype(float)
+        y = np.hstack([[0], np.full(9, MISSING_LABEL)])
+        clf = SklearnClassifier(LogisticRegression(), classes=self.classes)
+        first_indices = set()
+        for random_state in [0, 1, 42, 123, 2024]:
+            query_indices, utilities = Badge(random_state=random_state).query(
+                X, y, clf, batch_size=3, return_utilities=True
+            )
+            first_indices.add(int(query_indices[0]))
+            self.assertEqual(len(np.unique(query_indices)), 3)
+            np.testing.assert_allclose(utilities[0, 1:], 1 / 9)
+        self.assertGreater(len(first_indices), 1)
+
+    def test_query_labeled_candidates(self):
+        # If `candidates` contains labeled samples, `batch_size` is reduced to
+        # the number of unlabeled candidates.
+        X = np.random.RandomState(0).rand(10, 2)
+        y = np.hstack([np.tile([0, 1], 3), np.full(4, MISSING_LABEL)])
+        clf = SklearnClassifier(
+            LogisticRegression(), classes=self.classes, random_state=0
+        )
+        with self.assertWarns(UserWarning):
+            query_indices = Badge(random_state=0).query(
+                X, y, clf, candidates=np.arange(10), batch_size=5
+            )
+        np.testing.assert_array_equal(np.sort(query_indices), np.arange(6, 10))
+
+        # If `candidates` contains no unlabeled sample at all, there is
+        # nothing left to select.
+        self.assertRaises(
+            ValueError,
+            Badge(random_state=0).query,
+            X=X,
+            y=y,
+            clf=clf,
+            candidates=np.arange(6),
+        )
+
+    def test_query_candidates_as_sample_matrix(self):
+        # Candidates that are given as a sample matrix are indexed directly.
+        random_state = np.random.RandomState(3)
+        X = random_state.rand(20, 4)
+        y = np.hstack([[0, 1], np.full(18, MISSING_LABEL)])
+        candidates = random_state.rand(15, 4)
+        clf = SklearnClassifier(
+            LogisticRegression(), classes=self.classes, random_state=3
+        )
+        query_indices, utilities = Badge(random_state=3).query(
+            X,
+            y,
+            clf,
+            candidates=candidates,
+            batch_size=5,
+            return_utilities=True,
+        )
+        self.assertEqual(utilities.shape, (5, 15))
+        self.assertEqual(len(np.unique(query_indices)), 5)
+        self.assertTrue(np.all((query_indices >= 0) & (query_indices < 15)))
+        np.testing.assert_allclose(np.nansum(utilities, axis=1), 1)
+
+    def test_query_clf_embedding(self):
+        # With `clf_embedding_flag_name`, the sampling distribution is built
+        # on the returned embeddings instead of on `X`.
+        X = np.random.RandomState(7).rand(30, 3)
+        y = np.hstack([[0, 1], np.full(28, MISSING_LABEL)])
+        clf = SklearnClassifierCosineEmbedding(
+            LogisticRegression(), classes=self.classes, random_state=7
+        )
+        query_indices, utilities = Badge(
+            clf_embedding_flag_name="return_embeddings", random_state=7
+        ).query(X, y, clf, batch_size=4, return_utilities=True)
+        self.assertEqual(len(np.unique(query_indices)), 4)
+        np.testing.assert_allclose(np.nansum(utilities, axis=1), 1)
+
+        # Rebuild the first round from explicitly materialized gradients.
+        unlbld_mapping = np.arange(2, 30)
+        probas, embeddings = clf.fit(X, y).predict_proba(
+            X[unlbld_mapping], return_embeddings=True
+        )
+        proba_factor = probas - np.eye(probas.shape[1])[probas.argmax(-1)]
+        norms_2_emb = np.sum(
+            (proba_factor[:, :, None] * embeddings[:, None, :]) ** 2,
+            axis=(-2, -1),
+        )
+        norms_2_X = np.sum(
+            (proba_factor[:, :, None] * X[unlbld_mapping][:, None, :]) ** 2,
+            axis=(-2, -1),
+        )
+        self.assertEqual(
+            query_indices[0], unlbld_mapping[np.argmax(norms_2_emb)]
+        )
+        np.testing.assert_allclose(
+            utilities[0, unlbld_mapping],
+            norms_2_emb / norms_2_emb.sum(),
+            rtol=1e-9,
+        )
+        # The distribution built on `X` differs, such that the embeddings are
+        # indeed the ones being used.
+        self.assertFalse(
+            np.allclose(
+                utilities[0, unlbld_mapping], norms_2_X / norms_2_X.sum()
+            )
         )


### PR DESCRIPTION
Closes #586
Closes #587
Closes #588
Closes #589

**Additional context**

`Badge.query` now follows the k-means++ semantics of the BADGE reference
implementation and no longer materializes the gradient embeddings.

**Fixes**
- `D^2` is reset to the distance to the first center, so the origin is no
  longer a permanent ghost center (#588).
- `D^2` of the selected centers is zeroed instead of resetting the running
  minimum with `inf`, so no index is returned twice per batch (#586).
- Each `utilities` row is normalized before the selected samples are
  masked, so its `nansum` is one (#587).
- `batch_size` is clamped with a warning if `candidates` is an index array
  holding labeled samples, which previously crashed on `np.nan`
  probabilities.
- If all gradient embeddings are zero, samples are drawn uniformly at
  random and the first pick is controlled by `random_state` as well.

**Efficiency (#589)**
- `<g_i, g_j> = <q_i, q_j> * <v_i, v_j>` replaces the
  `(n_samples, n_classes * n_features)` matrix, which reduces the
  per-round complexity from `O(n * C * d)` to `O(n * (C + d))`.

**Behavioral changes**
- The selected indices change for a given `random_state`. The
  factorization alone is numerically equivalent, but the fixes above
  necessarily alter the sampling, i.e., the corresponding claim in #589
  holds only for the factorization in isolation.
- `query_indices` is a `numpy.ndarray` instead of a `list`, as documented.
- The embeddings are computed in `float64`, since the accumulation error
  of `float32` is large enough to change the sampling.

**Tests**
The existing cases are kept and one regression test per issue is added.
`test_query_matches_reference_kmeanspp` compares every round's utilities
against explicitly materialized embeddings with `rtol=1e-9`.
