### PR TITLE
Reject empty candidate arrays in stream query strategy update.

### DIFF
--- a/skactiveml/stream/_density_uncertainty.py
+++ b/skactiveml/stream/_density_uncertainty.py
@@ -215,6 +215,7 @@ class StreamDensityBasedAL(SingleAnnotatorStreamQueryStrategy):
         self : SingleAnnotatorStreamQueryStrategy
             The query strategy returns itself, after it is updated.
         """
+        candidates, _ = super()._validate_data(candidates, False)
         # check if a budget_manager is set
         if not hasattr(self, "budget_manager_"):
             self._validate_random_state()
@@ -707,6 +708,7 @@ class CognitiveDualQueryStrategy(SingleAnnotatorStreamQueryStrategy):
         self : CognitiveDualQueryStrategy
             The query strategy returns itself, after it is updated.
         """
+        candidates, _ = super()._validate_data(candidates, False)
         self._validate_force_full_budget()
         # check if a budget_manager is set
         if not hasattr(self, "budget_manager_"):

--- a/skactiveml/stream/_stream_baselines.py
+++ b/skactiveml/stream/_stream_baselines.py
@@ -121,8 +121,7 @@ class StreamRandomSampling(SingleAnnotatorStreamQueryStrategy):
         self : SingleAnnotatorStreamQueryStrategy
             The query strategy returns itself, after it is updated.
         """
-        # check if a random state is set
-        self._validate_data([[0]], False)
+        candidates, _ = self._validate_data(candidates, False)
         # update observed samples and queried samples
         queried = np.zeros(len(candidates))
         queried[queried_indices] = 1
@@ -287,8 +286,7 @@ class PeriodicSampling(SingleAnnotatorStreamQueryStrategy):
         self : SingleAnnotatorStreamQueryStrategy
             The query strategy returns itself, after it is updated.
         """
-        # check if a budgetmanager is set
-        self._validate_data(np.array([[0]]), False)
+        candidates, _ = self._validate_data(candidates, False)
         queried = np.zeros(len(candidates))
         queried[queried_indices] = 1
         self.observed_samples_ += len(queried)

--- a/skactiveml/stream/_stream_probabilistic_al.py
+++ b/skactiveml/stream/_stream_probabilistic_al.py
@@ -218,6 +218,7 @@ class StreamProbabilisticAL(SingleAnnotatorStreamQueryStrategy):
         self : SingleAnnotatorStreamQueryStrategy
             The query strategy returns itself, after it is updated.
         """
+        candidates, _ = super()._validate_data(candidates, False)
         # check if a budgetmanager is set
         if not hasattr(self, "budget_manager_"):
             check_type(

--- a/skactiveml/stream/_uncertainty_zliobaite.py
+++ b/skactiveml/stream/_uncertainty_zliobaite.py
@@ -171,6 +171,7 @@ class UncertaintyZliobaite(SingleAnnotatorStreamQueryStrategy):
         self : SingleAnnotatorStreamQueryStrategy
             The query strategy returns itself, after it is updated.
         """
+        candidates, _ = super()._validate_data(candidates, False)
         # check if a budgetmanager is set
         if not hasattr(self, "budget_manager_"):
             self._validate_random_state()

--- a/skactiveml/tests/template_query_strategy.py
+++ b/skactiveml/tests/template_query_strategy.py
@@ -659,7 +659,7 @@ class TemplateSingleAnnotatorStreamQueryStrategy(TemplateQueryStrategy):
             query_default_params_reg,
         )
         self.update_params = {
-            "candidates": [[]],
+            "candidates": [[0]],
             "queried_indices": [],
         }
 
@@ -1048,7 +1048,7 @@ class TemplateSingleAnnotatorStreamQueryStrategy(TemplateQueryStrategy):
 
     def test_update_param_candidates(self, test_cases=None):
         test_cases = [] if test_cases is None else test_cases
-        test_cases += [(Dummy, TypeError), ([[]], None), ([[0]], None)]
+        test_cases += [(Dummy, ValueError), ([[]], ValueError), ([[0]], None)]
         self._test_param("update", "candidates", test_cases)
 
     def test_update_param_queried_indices(self, test_cases=None):


### PR DESCRIPTION
Closes #360

`update` now passes the real `candidates` into the existing `_validate_data`
path (`return_utilities=False`) so `candidates=[]` / `[[]]` raise `ValueError`
via `sklearn.utils.check_array`, matching `query`.

The stream baselines validated a dummy `[[0]]` and then used the raw
`candidates`. The other stream strategies forwarded `candidates` to the budget
manager without an array check. `update([[]], [])` was accepted, or failed with
`AttributeError` / `TypeError` instead of `ValueError`.

**Decision:** reuse `_validate_data` with `return_utilities=False` rather
than implementing #357 (default arguments / a `validate_query` flag).
Alternative: land #357 first and call the subclass validator from `update`.
Passing `False` is enough to put `update` on the same `check_array` path
`query` already uses, and the #357 defaults can be added in a follow-up.

**Additional context**
> Default `update` test candidates changed from `[[]]` to `[[0]]` so
> other `update` parameter tests still have a valid array.
> `Dummy` now expects `ValueError` rather than `TypeError`, matching
> `test_query_param_candidates` (`check_array` on a type is a `ValueError`).
